### PR TITLE
fix: use form data for delete torrents

### DIFF
--- a/qbittorrent_rust/src/api_fns/torrents/torrent_managing_misc.rs
+++ b/qbittorrent_rust/src/api_fns/torrents/torrent_managing_misc.rs
@@ -282,13 +282,16 @@ impl QbitApi {
         let hashes: TorrentHashesDesc = hashes.borrow().clone();
         let hashes_str = hashes.get_string("|");
 
-        let url = url!(
-            "/torrents/delete",
-            ("hashes", Some(hashes_str)),
-            ("deleteFiles", Some(delete_files))
-        );
+        let url = String::from("/torrents/delete");
 
-        self.make_request(url, stringify!($func_name))
+        self.make_request_with_form(
+                url,
+                stringify!($func_name),
+                HashMap::from([
+                    ("hashes", Some(hashes_str)),
+                    ("deleteFiles", Some(delete_files.to_string()))
+                ])
+            )
             .await
             .map_err(|e| Error::build(ErrorType::ReqwestError(Box::new(e)), None))?;
 


### PR DESCRIPTION
the endpoint returns 400 if it's not sent as if it were form data
I've checked with default webui (5.0.2) which also sends it as form data,
the [official webui api docs](https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)) appear to be wrong, likely outdated as the version I use is newer than the documentation

Changes:
- updated torrents_delete_torrents to pass `hashes` and `deleteFiles` as form-data instead of query

I'm not sure if reqwest is supposed to automatically convert that query string into raw data and it being a reqwest bug